### PR TITLE
add extensions for Sandbox Unit Organizer 1.6+

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -28,6 +28,9 @@
     "live_game_build_bar": [
       "coui://ui/mods/com.pa.legion-expansion/live_game_build_bar.js"
     ],
+    "live_game_sandbox": [
+      "coui://ui/mods/com.pa.legion-expansion/live_game_sandbox.js"
+    ],
     "new_game": [
       "coui://ui/mods/com.pa.legion-expansion/new_game.js"
     ]

--- a/ui/mods/com.pa.legion-expansion/live_game_sandbox.js
+++ b/ui/mods/com.pa.legion-expansion/live_game_sandbox.js
@@ -1,0 +1,47 @@
+var legionExpansionLoaded;
+
+if ( ! legionExpansionLoaded )
+{
+
+    legionExpansionLoaded = true;
+
+    function legionExpansion()
+    {
+
+        var buildVersion = decode( sessionStorage.build_version );
+
+        var patchName = 'legionExpansion live_game_sandbox.js';
+
+        console.log(patchName + ' on ' + buildVersion + ' last tested on 89755');
+
+        if (model.baseGroups) {
+            model.baseGroups.splice(99, 0, 
+                'L_factory',
+                'L_combat',
+                'L_utility',
+                'L_orbital_structure',
+                'L_ammo')
+        }
+        if (model.mobileGroups) {
+            model.mobileGroups.splice(99, 0, 
+                'L_vehicle',
+                'L_bot',
+                'L_air',
+                'L_sea',
+                'L_orbital')
+        }
+        if (model.miscUnits) {
+            model.miscUnits.push('/pa/units/commanders/imperial_fiveleafclover/imperial_fiveleafclover.json')
+        }
+    }
+
+    try
+    {
+        legionExpansion();
+    }
+    catch (e)
+    {
+        console.log(e);
+        console.log(JSON.stringify(e));
+    }
+}


### PR DESCRIPTION
Default layout for new build tabs actually did well, but this adds fiveleafclover for build testing.