### PR TITLE
Update imperial_legion.json

### DIFF
--- a/pa/ai/unit_maps/imperial_legion.json
+++ b/pa/ai/unit_maps/imperial_legion.json
@@ -1,181 +1,262 @@
-{
+	{
   "unit_map": {
-    "AnyLegionAdvancedFabber": {
+    "AnyLegionFabberAdvanced": {
       "unit_types": "(Fabber & (Advanced | Debug) & Custom1) - Orbital"
     },
-    "AnyLegionAdvancedFactory": {
-      "unit_types": "Factory & Advanced & Custom1"
-    },
-    "AnyLegionBasicFabber": {
+    "AnyLegionFabberBasic": {
       "unit_types": "(Fabber & (Basic | Debug) & Custom1) - Orbital"
     },
-    "AnyLegionBasicFactory": {
-      "unit_types": "Factory & Basic & Custom1"
+    "AnyLegionFactoryAdvanced": {
+      "unit_types": "(Factory & Advanced) & Custom1"
     },
-    "LegionAdvancedAirDefense": {
-      "spec_id": "/pa/units/land/L_air_defense_adv/L_air_defense_adv.json"
-    },
-    "LegionAdvancedAirFactory": {
-      "spec_id": "/pa/units/air/L_air_factory_adv/L_air_factory_adv.json"
-    },
-    "LegionAdvancedArmorVehicle": {
-      "spec_id": "/pa/units/land/L_tank_heavy_armor/L_tank_heavy_armor.json"
-    },
-    "LegionAdvancedArtillery": {
-      "spec_id": "/pa/units/land/L_artillery_long/L_artillery_long.json"
-    },
-    "LegionAdvancedArtilleryBot": {
-      "spec_id": "/pa/units/land/L_bot_artillery_adv/L_bot_artillery_adv.json"
-    },
-    "LegionAdvancedAssaultBot": {
-      "spec_id": "/pa/units/land/L_assault_bot_adv/L_assault_bot_adv.json"
-    },
-    "LegionAdvancedBotFactory": {
-      "spec_id": "/pa/units/land/L_bot_factory_adv/L_bot_factory_adv.json"
-    },
-    "LegionAdvancedCombatFabberBot": {
-      "spec_id": "/pa/units/land/L_fabrication_bot_combat_adv/L_fabrication_bot_combat_adv.json"
-    },
-    "LegionAdvancedEnergyPlant": {
-      "spec_id": "/pa/units/land/L_energy_plant_adv/L_energy_plant_adv.json"
-    },
-    "LegionAdvancedFabberVehicle": {
-      "spec_id": "/pa/units/land/L_fabrication_vehicle_adv/L_fabrication_vehicle_adv.json"
-    },
-    "LegionAdvancedFabricationBot": {
-      "spec_id": "/pa/units/land/L_fabrication_bot_adv/L_fabrication_bot_adv.json"
-    },
-    "LegionAdvancedLaserVehicle": {
-      "spec_id": "/pa/units/land/L_tank_laser_adv/L_tank_laser_adv.json"
-    },
-    "LegionAdvancedMetalExtractor": {
-      "spec_id": "/pa/units/land/L_mex_adv/L_mex_adv.json"
-    },
-    "LegionAdvancedNavalFactory": {
-      "spec_id": "/pa/units/sea/L_naval_factory_adv/L_naval_factory_adv.json"
-    },
-    "LegionAdvancedOrbitalFactory": {
-      "spec_id": "/pa/units/orbital/L_orbital_factory/L_orbital_factory.json"
-    },
-    "LegionAdvancedRadar": {
-      "spec_id": "/pa/units/land/L_radar_adv/L_radar_adv.json"
-    },
-    "LegionAdvancedSniperVehicle": {
-      "spec_id": "/pa/units/land/L_sniper_tank/L_sniper_tank.json"
-    },
-    "LegionAdvancedT1LaserDefense": {
-      "spec_id": "/pa/units/land/L_t1_turret_adv/L_t1_turret_adv.json"
-    },
-    "LegionAdvancedTML": {
-      "spec_id": "/pa/units/land/L_rocket_barrage/L_rocket_barrage.json"
-    },
-    "LegionAdvancedTacticalBot": {
-      "spec_id": "/pa/units/land/L_bot_tactical_missile/L_bot_tactical_missile.json"
-    },
-    "LegionAdvancedTurret": {
-      "spec_id": "/pa/units/land/L_laser_defense_adv/L_laser_defense_adv.json"
-    },
-    "LegionAdvancedVehicleFactory": {
-      "spec_id": "/pa/units/land/L_vehicle_factory_adv/L_vehicle_factory_adv.json"
-    },
-    "LegionAntiNukeSilo": {
-      "spec_id": "/pa/units/land/L_anti_nuke_launcher/L_anti_nuke_launcher.json"
-    },
-    "LegionBasicAABot": {
-      "spec_id": "/pa/units/land/L_bot_aa/L_bot_aa.json"
-    },
-    "LegionBasicAirDefense": {
-      "spec_id": "/pa/units/land/L_air_defense/L_air_defense.json"
-    },
-    "LegionBasicAirFactory": {
-      "spec_id": "/pa/units/air/L_air_factory/L_air_factory.json"
-    },
-    "LegionBasicArtillery": {
-      "spec_id": "/pa/units/land/L_artillery_short/L_artillery_short.json"
-    },
-    "LegionBasicArtilleryBot": {
-      "spec_id": "/pa/units/land/L_artillery_bot/L_artillery_bot.json"
-    },
-    "LegionBasicAssaultBot": {
-      "spec_id": "/pa/units/land/L_assault_bot/L_assault_bot.json"
-    },
-    "LegionBasicBombBot": {
-      "spec_id": "/pa/units/land/L_bot_bomb/L_bot_bomb.json"
-    },
-    "LegionBasicBomber": {
-      "spec_id": "/pa/units/air/L_bomber/L_bomber.json"
-    },
-    "LegionBasicBotFactory": {
-      "spec_id": "/pa/units/land/L_bot_factory/L_bot_factory.json"
-    },
-    "LegionBasicCombatFabberBot": {
-      "spec_id": "/pa/units/land/L_fabrication_bot_combat/L_fabrication_bot_combat.json"
-    },
-    "LegionBasicEnergyPlant": {
-      "spec_id": "/pa/units/land/L_energy_plant/L_energy_plant.json"
-    },
-    "LegionBasicFabberVehicle": {
-      "spec_id": "/pa/units/land/L_fabrication_vehicle/L_fabrication_vehicle.json"
-    },
-    "LegionBasicFabricationBot": {
-      "spec_id": "/pa/units/land/L_fabrication_bot/L_fabrication_bot.json"
-    },
-    "LegionBasicFighter": {
-      "spec_id": "/pa/units/air/L_fighter/L_fighter.json"
-    },
-    "LegionBasicHoverVehicle": {
-      "spec_id": "/pa/units/land/tank_hover/tank_hover.json"
-    },
-    "LegionBasicMetalExtractor": {
-      "spec_id": "/pa/units/land/L_mex/L_mex.json"
-    },
-    "LegionBasicMortarVehicle": {
-      "spec_id": "/pa/units/land/L_mortar_tank/L_mortar_tank.json"
-    },
-    "LegionBasicNavalFactory": {
-      "spec_id": "/pa/units/sea/L_naval_factory/L_naval_factory.json"
-    },
-    "LegionBasicRadar": {
-      "spec_id": "/pa/units/land/L_radar/L_radar.json"
-    },
-    "LegionBasicRiotBot": {
-      "spec_id": "/pa/units/land/L_riot_bot/L_riot_bot.json"
-    },
-    "LegionBasicShankVehicle": {
-      "spec_id": "/pa/units/land/L_tank_shank/L_tank_shank.json"
-    },
-    "LegionBasicShotgunVehicle": {
-      "spec_id": "/pa/units/land/L_shotgun_tank/L_shotgun_tank.json"
-    },
-    "LegionBasicStorage": {
-      "spec_id": "/pa/units/land/L_storage/L_storage.json"
-    },
-    "LegionBasicT1LaserDefense": {
-      "spec_id": "/pa/units/land/L_t1_turret_basic/L_t1_turret_basic.json"
-    },
-    "LegionBasicVehicleFactory": {
-      "spec_id": "/pa/units/land/L_vehicle_factory/L_vehicle_factory.json"
+    "AnyLegionFactoryBasic": {
+      "unit_types": "(Factory & Basic) & Custom1"
     },
     "LegionCommander": {
       "unit_types": "Commander & Custom1"
     },
-    "LegionDestroyer": {
-      "spec_id": "/pa/units/sea/L_destroyer/L_destroyer.json"
+    "LegionAirAdvancedFabber": {
+      "spec_id": "/pa/units/air/L_fabrication_aircraft_adv/L_fabrication_aircraft_adv.json"
     },
-    "LegionMine": {
-      "spec_id": "/pa/units/land/L_land_mine/L_land_mine.json"
+    "LegionAirAdvancedGunship": {
+      "spec_id": "/pa/units/air/L_gunship/L_gunship.json"
     },
-    "LegionNukeSilo": {
+    "LegionAirAdvancedBomber": {
+      "spec_id": "/pa/units/air/L_bomber_adv/L_bomber_adv.json"
+    },
+    "LegionAirAdvancedCarrier": {
+      "spec_id": "/pa/units/air/L_air_carrier/L_air_carrier.json"
+    },
+    "LegionAirAdvancedFighter": {
+      "spec_id": "/pa/units/air/L_fighter_adv/L_fighter_adv.json"
+    },
+    "LegionAirAdvancedScout": {
+      "spec_id": "/pa/units/air/L_air_scout_adv/L_air_scout_adv.json"
+    },
+    "LegionAirAdvancedTeleporter": {
+      "spec_id": "/pa/units/air/L_flying_teleporter/L_flying_teleporter.json"
+    },
+    "LegionAirBasicBomber": {
+      "spec_id": "/pa/units/air/L_bomber/L_bomber.json"
+    },
+    "LegionAirBasicFabber": {
+      "spec_id": "/pa/units/air/L_fabrication_aircraft/L_fabrication_aircraft.json"
+    },
+    "LegionAirBasicFighter": {
+      "spec_id": "/pa/units/air/L_fighter/L_fighter.json"
+    },
+    "LegionAirBasicGunship": {
+      "spec_id": "/pa/units/air/L_raider/L_raider.json"
+    },
+    "LegionAirBasicTransport": {
+      "spec_id": "/pa/units/air/L_transport/L_transport.json"
+    },
+    "LegionBotAdvancedAA": {
+      "spec_id": "/pa/units/land/L_bot_tactical_missile/L_bot_tactical_missile.json"
+    },
+    "LegionBotAdvancedArtillery": {
+      "spec_id": "/pa/units/land/L_bot_artillery/L_bot_artillery.json"
+    },
+    "LegionBotAdvancedFabber": {
+      "spec_id": "/pa/units/land/L_fabrication_bot_adv/L_fabrication_bot_adv.json"
+    },
+    "LegionBotAdvancedRiot": {
+      "spec_id": "/pa/units/land/L_riot_bot/L_riot_bot.json"
+    },
+    "LegionBotAdvancedTactical": {
+      "spec_id": "/pa/units/land/L_bot_artillery_adv/L_bot_artillery_adv.json"
+    },
+    "LegionBotBasicAA": {
+      "spec_id": "/pa/units/land/L_bot_aa/L_bot_aa.json"
+    },
+    "LegionBotBasicAssault": {
+      "spec_id": "/pa/units/land/L_assault_bot/L_assault_bot.json"
+    },
+    "LegionBotBasicBomb": {
+      "spec_id": "/pa/units/land/L_bot_bomb/L_bot_bomb.json"
+    },
+    "LegionBotBasicFabber": {
+      "spec_id": "/pa/units/land/L_fabrication_bot/L_fabrication_bot.json"
+    },
+    "LegionBotBasicScout": {
+      "spec_id": "/pa/units/land/L_scout_bot/L_scout_bot.json"
+    },
+    "LegionBotBasicSniper": {
+      "spec_id": "/pa/units/land/L_sniper_bot/L_sniper_bot.json"
+    },
+    "LegionDefenseAdvancedAir": {
+      "spec_id": "/pa/units/land/L_air_defense_adv/L_air_defense_adv.json"
+    },
+    "LegionDefenseAdvancedAntiNukeSilo": {
+      "spec_id": "/pa/units/land/L_anti_nuke_launcher/L_anti_nuke_launcher.json"
+    },
+    "LegionDefenseAdvancedArtillery": {
+      "spec_id": "/pa/units/land/L_artillery_long/L_artillery_long.json"
+    },
+    "LegionDefenseAdvancedLand": {
+      "spec_id": "/pa/units/land/L_laser_defense_adv/L_laser_defense_adv.json"
+    },
+		"LegionDefenseAdvancedNaval": {
+			"spec_id": "/pa/units/sea/L_torpedo_launcher_adv/L_torpedo_launcher_adv.json"
+		},
+    "LegionDefenseAdvancedNukeSilo": {
       "spec_id": "/pa/units/land/L_nuke_launcher/L_nuke_launcher.json"
     },
-    "LegionScoutVehicle": {
-      "spec_id": "/pa/units/land/L_land_scout/L_land_scout.json"
+		"LegionDefenseAdvancedShield": {
+			"spec_id": "/pa/units/land/L_shield_gen/L_shield_gen.json"
+		},
+    "LegionDefenseAdvancedTactical": {
+      "spec_id": "/pa/units/land/L_rocket_barrage/L_rocket_barrage.json"
     },
-    "LegionTeleporter": {
+    "LegionDefenseBasicAir": {
+      "spec_id": "/pa/units/land/L_air_defense/L_air_defense.json"
+    },
+    "LegionDefenseBasicArtillery": {
+      "spec_id": "/pa/units/land/L_artillery_short/L_artillery_short.json"
+    },
+    "LegionDefenseBasicLand": {
+      "spec_id": "/pa/units/land/L_t1_turret_basic/L_t1_turret_basic.json"
+    },
+    "LegionDefenseBasicLandII": {
+      "spec_id": "/pa/units/land/L_t1_turret_adv/L_t1_turret_adv.json"
+    },
+		"LegionDefenseBasicNaval": {
+			"spec_id": "/pa/units/sea/L_torpedo_launcher/L_torpedo_launcher.json"
+		},		
+		"LegionBasicDefenseOrbital": {
+			"spec_id": "/pa/units/orbital/L_ion_defense/L_ion_defense.json"
+		},
+    "LegionEcoAdvancedEnergyPlant": {
+      "spec_id": "/pa/units/land/L_energy_plant_adv/L_energy_plant_adv.json"
+    },
+    "LegionEcoAdvancedMetalExtractor": {
+      "spec_id": "/pa/units/land/L_mex_adv/L_mex_adv.json"
+    },
+    "LegionEcoBasicEnergyPlant": {
+      "spec_id": "/pa/units/land/L_energy_plant/L_energy_plant.json"
+    },
+    "LegionEcoBasicMetalExtractor": {
+      "spec_id": "/pa/units/land/L_mex/L_mex.json"
+    },
+    "LegionEcoBasicStorage": {
+      "spec_id": "/pa/units/land/L_storage/L_storage.json"
+    },
+    "LegionFactoryAdvancedAir": {
+      "spec_id": "/pa/units/air/L_air_factory_adv/L_air_factory_adv.json"
+    },
+    "LegionFactoryAdvancedBot": {
+      "spec_id": "/pa/units/land/L_bot_factory_adv/L_bot_factory_adv.json"
+    },
+    "LegionFactoryAdvancedNaval": {
+      "spec_id": "/pa/units/sea/L_naval_factory_adv/L_naval_factory_adv.json"
+    },
+    "LegionFactoryAdvancedVehicle": {
+      "spec_id": "/pa/units/land/L_vehicle_factory_adv/L_vehicle_factory_adv.json"
+    },
+    "LegionFactoryBasicAir": {
+      "spec_id": "/pa/units/air/L_air_factory/L_air_factory.json"
+    },
+    "LegionFactoryBasicBot": {
+      "spec_id": "/pa/units/land/L_bot_factory/L_bot_factory.json"
+    },
+    "LegionFactoryBasicNaval": {
+      "spec_id": "/pa/units/sea/L_naval_factory/L_naval_factory.json"
+    },
+    "LegionFactoryBasicVehicle": {
+      "spec_id": "/pa/units/land/L_vehicle_factory/L_vehicle_factory.json"
+    },
+    "LegionIntelAdvancedRadar": {
+      "spec_id": "/pa/units/land/L_radar_adv/L_radar_adv.json"
+    },
+    "LegionIntelBasicRadar": {
+      "spec_id": "/pa/units/land/L_radar/L_radar.json"
+    },
+    "LegionNavalAdvancedBattleship": {
+      "spec_id": "/pa/units/sea/L_battleship/L_battleship.json"
+    },
+    "LegionNavalAdvancedFabber": {
+      "spec_id": "/pa/units/sea/L_fabrication_ship_adv/L_fabrication_ship_adv.json"
+    },
+    "LegionNavalAdvancedFabberSub": {
+      "spec_id": "/pa/units/sea/L_fabrication_sub_combat_adv/L_fabrication_sub_combat_adv.json"
+    },
+    "LegionNavalAdvancedSub": {
+      "spec_id": "/pa/units/sea/L_nuclear_sub/L_nuclear_sub.json"
+    },
+    "LegionNavalAdvancedTactical": {
+      "spec_id": "/pa/units/sea/L_missile_ship/L_missile_ship.json"
+    },
+    "LegionNavalBasicFabber": {
+      "spec_id": "/pa/units/sea/L_fabrication_ship/L_fabrication_ship.json"
+    },
+    "LegionNavalBasicAA": {
+      "spec_id": "/pa/units/sea/L_frigate/L_frigate.json"
+    },
+    "LegionNavalBasicDestroyer": {
+      "spec_id": "/pa/units/sea/L_destroyer/L_destroyer.json"
+    },
+    "LegionNavalBasicScout": {
+      "spec_id": "/pa/units/sea/L_sea_scout/L_sea_scout.json"
+    },
+    "LegionNavalBasicSub": {
+      "spec_id": "/pa/units/sea/L_attack_sub/L_attack_sub.json"
+    },
+    "LegionStructureBasicTeleporter": {
       "spec_id": "/pa/units/land/L_teleporter/L_teleporter.json"
     },
-    "LegionWall": {
+    "LegionStructureBasicWall": {
       "spec_id": "/pa/units/land/L_land_barrier/L_land_barrier.json"
+    },
+    "LegionTitanAdvancedAir": {
+      "spec_id": "/pa/units/air/L_titan_air/L_titan_air.json"
+    },
+    "LegionTitanAdvancedBot": {
+      "spec_id": "/pa/units/land/L_titan_bot/L_titan_bot.json"
+    },
+    "LegionTitanAdvancedOrbital": {
+      "spec_id": "/pa/units/orbital/L_titan_orbital/L_titan_orbital.json"
+    },
+    "LegionTitanAdvancedStructure": {
+      "spec_id": "/pa/units/land/L_titan_structure/L_titan_structure.json"
+    },
+    "LegionTitanAdvancedVehicle": {
+      "spec_id": "/pa/units/land/L_titan_vehicle/L_titan_vehicle.json"
+    },
+    "LegionVehicleAdvancedArmor": {
+      "spec_id": "/pa/units/land/L_tank_heavy_armor/L_tank_heavy_armor.json"
+    },
+    "LegionVehicleAdvancedAA": {
+      "spec_id": "/pa/units/land/L_tank_swarm/L_tank_swarm.json"
+    },
+    "LegionVehicleAdvancedFabber": {
+      "spec_id": "/pa/units/land/L_fabrication_vehicle_adv/L_fabrication_vehicle_adv.json"
+    },
+    "LegionVehicleAdvancedHover": {
+      "spec_id": "/pa/units/land/L_hover_tank_adv/L_hover_tank_adv.json"
+    },
+    "LegionVehicleAdvancedLaser": {
+      "spec_id": "/pa/units/land/L_tank_laser_adv/L_tank_laser_adv.json"
+    },
+    "LegionVehicleAdvancedSniper": {
+      "spec_id": "/pa/units/land/L_sniper_tank/L_sniper_tank.json"
+    },
+    "LegionVehicleBasicFabber": {
+      "spec_id": "/pa/units/land/L_fabrication_vehicle/L_fabrication_vehicle.json"
+    },
+    "LegionVehicleBasicHover": {
+      "spec_id": "/pa/units/land/L_hover_tank/L_hover_tank.json"
+    },
+    "LegionVehicleBasicMortar": {
+      "spec_id": "/pa/units/land/L_mortar_tank/L_mortar_tank.json"
+    },
+    "LegionVehicleBasicScout": {
+      "spec_id": "/pa/units/land/L_land_scout/L_land_scout.json"
+    },
+    "LegionVehicleBasicShank": {
+      "spec_id": "/pa/units/land/L_tank_shank/L_tank_shank.json"
+    },
+    "LegionVehicleBasicShotgun": {
+      "spec_id": "/pa/units/land/L_shotgun_tank/L_shotgun_tank.json"
     }
   }
 }


### PR DESCRIPTION
File hasn't been maintained. Added the missing units and removed all the units which no longer exist/are no longer used.

Updated names in the format - FACTION - TYPE - TIER - ROLE

As the Legion unit documentation is out-of-date this file may require additional work. It's possible the wrong units are being called in some cases because there's no way to cross-check many of the unit files with the documentation available. Orbital factories not included yet as they're not in the unit doc.

The mod's filenames are a mess :p