### PR TITLE
Update imperial_legion.json

### DIFF
--- a/pa/ai/unit_maps/imperial_legion.json
+++ b/pa/ai/unit_maps/imperial_legion.json
@@ -249,6 +249,9 @@
     "LegionVehicleAdvancedSniper": {
       "spec_id": "/pa/units/land/L_sniper_tank/L_sniper_tank.json"
     },
+    "LegionVehicleBasicArmor": {
+      "spec_id": "/pa/units/land/L_shotgun_tank/L_shotgun_tank.json"
+    },
     "LegionVehicleBasicArtillery": {
       "spec_id": "/pa/units/land/L_mortar_tank/L_mortar_tank.json"
     },
@@ -263,9 +266,6 @@
     },
     "LegionVehicleBasicLaser": {
       "spec_id": "/pa/units/land/L_tank_shank/L_tank_shank.json"
-    },
-    "LegionVehicleBasicShotgun": {
-      "spec_id": "/pa/units/land/L_shotgun_tank/L_shotgun_tank.json"
     }
   }
 }


### PR DESCRIPTION
Maul (shotgun tank) was using the wrong name. Now brought in line with standard naming conventions.