### PR TITLE
Air Bomb fixes …

### DIFF
--- a/pa/units/air/L_air_bomb/triggered/L_air_bomb_ammo.json
+++ b/pa/units/air/L_air_bomb/triggered/L_air_bomb_ammo.json
@@ -1,30 +1,60 @@
 {
-  "base_spec": "/pa/ammo/base_missiles/base_missile_aa_seeking.json",
-  "damage": 140,
-  "events": {
-    "died": {
-      "audio_cue": "/SE/Impacts/bomb_bot_plasma",
-      "effect_spec": "/pa/units/land/bot_bomb/bot_bomb_ammo_explosion.pfx"
-    }
-  },
-  "full_splash_damage_radius": 3,
-  "fx_trail": {
-    "filename": "/pa/units/air/L_air_bomb/triggered/L_air_bomb.pfx",
-    "offset": [
-      0.0,
-      0.0,
-      0.0
-    ]
-  },
-  "initial_velocity": 200,
-  "lifetime": 4,
-  "max_velocity": 500,
-  "min_velocity": 100,
-  "model": {
-    "filename": "/pa/units/air/L_air_bomb/L_air_bomb.papa"
-  },
-  "splash_damage": 140,
-  "splash_damages_allies": true,
-  "splash_radius": 30,
-  "turn_rate": 1080
+	"ammo_type": "AMMO_Projectile",
+	"armor_damage_map": {
+		"AT_Air": 1.0,
+		"AT_Bot": 0.0,
+		"AT_Commander": 0.0,
+		"AT_Hover": 0.0,
+		"AT_Naval": 0.0,
+		"AT_Orbital": 0.0,
+		"AT_Structure": 0.0,
+		"AT_Vehicle": 0.0
+	},
+	"base_spec": "/pa/ammo/base_missiles/base_missile_tactical.json",
+	"cruise_height": 20,
+	"damage": 140,
+	"events": {
+		"died": {
+			"audio_cue": "/SE/Impacts/bomb_bot_plasma",
+			"effect_spec": "/pa/units/land/bot_bomb/bot_bomb_ammo_explosion.pfx"
+		}
+	},
+	"full_splash_damage_radius": 3,
+	"fx_trail": {
+		"filename": "/pa/units/air/L_air_bomb/triggered/L_air_bomb.pfx",
+		"offset": [
+			0.0,
+			0.0,
+			0.0
+		]
+	},
+	"initial_velocity": 650,
+	"lifetime": 2.5,
+	"max_velocity": 650,
+	"model": {
+		"filename": "/pa/units/air/L_air_bomb/L_air_bomb.papa"
+	},
+	"splash_damage": 140,
+	"splash_damages_allies": true,
+	"splash_radius": 30,
+	"turn_rate": 1080,
+	"flight_type": "Staged",
+	"max_health": 1,
+	"physics": {
+		"add_to_spatial_db": false,
+		"allow_underground": true,
+		"gravity_scalar": 1,
+		"radius": 10
+	},
+	"stages": [{
+		"ignores_LOS": true,
+		"ignores_gravity": true,
+		"rotates_to_velocity": true,
+		"stage_duration": 100,
+		"stage_turn_rate": 0
+	},
+	{
+		"die_here": true
+	}
+	]
 }

--- a/pa/units/air/L_air_bomb/triggered/L_air_bomb_tool_weapon.json
+++ b/pa/units/air/L_air_bomb/triggered/L_air_bomb_tool_weapon.json
@@ -1,10 +1,10 @@
 {
   "ammo_id": "/pa/units/air/L_air_bomb/triggered/L_air_bomb_ammo.json",
   "auto_attack": true,
-  "base_spec": "/pa/tools/base_missile_turret/base_missile_turret.json",
+  "base_spec": "/pa/tools/base_shell_turret/base_shell_turret.json",
   "firing_arc_pitch": 180,
   "firing_arc_yaw": 360,
-  "max_range": 15,
+  "max_range": 35,
   "pitch_range": 180,
   "pitch_rate": 3600,
   "rate_of_fire": 1,
@@ -14,5 +14,6 @@
     "WL_Air"
   ],
   "yaw_range": 360,
-  "yaw_rate": 3600
+  "yaw_rate": 3600,
+  "firing_standard_deviation": 10
 }


### PR DESCRIPTION
Changed weapon and ammo so they explode far enough away that it doesn't blow up the group of bombs it is in. This makes them more predictable, with a better metal kill/loss ratio, and easier to balance. 
See below for data and to be able to interactively change metal costs to see how the ratio changes based on air bomb group size.
https://docs.google.com/spreadsheets/d/1KRZA8gbvdUiOtUmOPhYZWVPJ_-18jnxn9xkfkkn1itM/edit#gid=1320007979