### PR TITLE
Description changes - land air #217

### DIFF
--- a/server/pa/units/land/L_bot_bomb/L_bot_bomb.json
+++ b/server/pa/units/land/L_bot_bomb/L_bot_bomb.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Purger",
-  "description": "Leaping Boombot Spider - Launches Itself at Enemies.",
+  "description": "Leaping Boombot Spider - Launches at Enemies and up Cliffs.",
   "TEMP_texelinfo": 6.38702,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_mex/L_mex.json
+++ b/server/pa/units/land/L_mex/L_mex.json
@@ -1,6 +1,6 @@
 {
-  "display_name": "Mass Extractor",
-  "description": "Mass-Lode Extractor - Extracts Metal to Support Economic Expansion.",
+  "display_name": "Metal Extractor",
+  "description": "Extracts Metal, can only be placed on metal deposits.",
   "TEMP_texelinfo": 15.0973,
   "area_build_type": "Sphere",
   "atrophy_cool_down": 15,

--- a/server/pa/units/land/L_mex_adv/L_mex_adv.json
+++ b/server/pa/units/land/L_mex_adv/L_mex_adv.json
@@ -1,6 +1,6 @@
 {
-  "display_name": "Advanced Mass Extractor",
-  "description": "Advanced Mass-Lode Extractor - Extracts Metal to Support Economic Expansion.",
+  "display_name": "Advanced Metal Extractor",
+  "description": "Extracts Metal, can only be placed on metal deposits.",
   "TEMP_texelinfo": 24.4307,
   "area_build_type": "Sphere",
   "atrophy_cool_down": 15.0,

--- a/server/pa/units/land/L_mortar_tank/L_mortar_tank.json
+++ b/server/pa/units/land/L_mortar_tank/L_mortar_tank.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Bandit",
-  "description": "Amphibious Tank - Fast Attack Tank. Equipped with Torpedoes a Laser Cannon.",
+  "description": "Fast Amphibious Attack Tank. Equipped with Torpedoes and a Light Cannon.",
   "TEMP_texelinfo": 9.31488,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_riot_bot/L_riot_bot.json
+++ b/server/pa/units/land/L_riot_bot/L_riot_bot.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Enforcer",
-  "description": "Heavy Assault Walker. Short Range. Attacks Land and Naval.",
+  "description": "Advanced Assault Walker. High Damage Gatling Guns. Attacks Land and Naval.",
   "TEMP_texelinfo": 10,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_rocket_barrage/L_rocket_barrage.json
+++ b/server/pa/units/land/L_rocket_barrage/L_rocket_barrage.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Decimator",
-  "description": "Advanced Defense - Medium Range Heavy Rocket Pods. Attacks Land and Naval Targets.",
+  "description": "Advanced Defense - Heavy Rocket Pods. Attacks Land and Naval.",
   "TEMP_texelinfo": 15.8261,
   "atrophy_cool_down": 15,
   "atrophy_rate": 30,

--- a/server/pa/units/land/L_scout_bot/L_scout_bot.json
+++ b/server/pa/units/land/L_scout_bot/L_scout_bot.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Creeper",
-  "description": "Scout Bot. Provides Short Range Vision and Radar Coverage.",
+  "description": "Scout Bot. Deploys into a Hidden Short Range Radar.",
   "TEMP_texelinfo": 4.07719,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_shotgun_tank/L_shotgun_tank.json
+++ b/server/pa/units/land/L_shotgun_tank/L_shotgun_tank.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Maul",
-  "description": "Close Range Support. Shotgun. Attacks Land and Naval.",
+  "description": "Close Range Shotgun Tank. Attacks Land and Naval.",
   "TEMP_texelinfo": 14.523,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_t1_turret_adv/L_t1_turret_adv.json
+++ b/server/pa/units/land/L_t1_turret_adv/L_t1_turret_adv.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Scarab",
-  "description": "Medium Defense Turret. Short Range. Attacks Land and Naval Targets.",
+  "description": "Medium Defense Turret. Attacks Land and Naval Targets.",
   "TEMP_texelinfo": 23.9812,
   "area_build_separation": 18,
   "atrophy_cool_down": 15,

--- a/server/pa/units/land/L_tank_heavy_armor/L_tank_heavy_armor.json
+++ b/server/pa/units/land/L_tank_heavy_armor/L_tank_heavy_armor.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Earthshaker",
-  "description": "Seismic Tank - Decimates Units That Get Too Close Within its Range.",
+  "description": "Seismic Tank - Decimates Units That Get Too Close.",
   "TEMP_texelinfo": 9.04444,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_tank_shank/L_tank_shank.json
+++ b/server/pa/units/land/L_tank_shank/L_tank_shank.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Shank",
-  "description": "Main Battle Tank - Lightly Armored. Attacks Land and Naval.",
+  "description": "Main Battle Tank - Slow but reliable. Attacks Land and Naval.",
   "TEMP_texelinfo": 5.84968,
   "attachable": {
     "offsets": {

--- a/server/pa/units/land/L_teleporter/L_teleporter.json
+++ b/server/pa/units/land/L_teleporter/L_teleporter.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Sky Bridge",
-  "description": "Teleportation Device - Instantaneously Transports Units From Point A to Point B.",
+  "description": "Teleportation Device - Teleports units from one to another.",
   "TEMP_texelinfo": 30.032139,
   "area_build_type": "Line",
   "atrophy_cool_down": 15,

--- a/server/pa/units/land/L_titan_bot/L_titan_bot.json
+++ b/server/pa/units/land/L_titan_bot/L_titan_bot.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Thor",
-  "description": "Assault Titan - Equipped with an Arsenal of Highly Destructive Weapons.",
+  "description": "Experimental Assault Titan - Equipped with an Arsenal of Highly Destructive Weapons.",
   "TEMP_texelinfo": 35.2973,
   "atrophy_cool_down": 15.0,
   "atrophy_rate": 200.0,

--- a/server/pa/units/land/L_titan_vehicle/L_titan_vehicle.json
+++ b/server/pa/units/land/L_titan_vehicle/L_titan_vehicle.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Odin",
-  "description": "Rolling Fortress - Long Range. Heavily Armored and Deals Very High Damage.",
+  "description": "Experimental Rolling Fortress - Long Range. Heavily Armored and Deals Very High Damage.",
   "TEMP_texelinfo": 35.95324,
   "armor_type": "AT_Hover",
   "atrophy_cool_down": 15.0,


### PR DESCRIPTION
- add up cliffs to purger
- change mex/advmex to reflect actual resource names in PA
- Collapse mortar tank a bit. remove laser
- Replace heavy and short range on riot bot
- Remove medium range from rocket barrage
- More accurate function description for scout bot
- Remove support and one word sentence from Maul
- Remove short range from t1 turret adv
- Remove "within its range" from earth shaker
- Replace lightly armored on Shank
- Collapse teleporter description into mirror of vanilla teleporter
- Add experimental to titan bot and titan vehicle