### PR TITLE
Depend on custom weapon tracking

### DIFF
--- a/server/modinfo.json
+++ b/server/modinfo.json
@@ -12,7 +12,7 @@
     "com.pa.quitch.qAIModCompatibilityPatch",
     "com.pa.legion-expansion-client",
     "com.wondible.pa.hodgepodge",
-    "com.wondible.pa.weapons_tracking"
+    "com.pa.domdom.weapons_tracking.server"
   ],
   "companions": [
     "com.pa.legion-expansion-client"


### PR DESCRIPTION
Uses my custom weapons tracking mod. Only adds ammo to the spacial db if it is an antientity target. Also allows other mods to override the weapon effects of each of those ammo specs.