### PR TITLE
Fix monstrosity aim animation

### DIFF
--- a/src/server/pa/anim/anim_trees/l_bot_artillery_adv_anim_tree.json
+++ b/src/server/pa/anim/anim_trees/l_bot_artillery_adv_anim_tree.json
@@ -42,7 +42,8 @@
       "child": {
         "rotation_axis": "z",
         "rotation_bone": "bone_turret",
-        "type": "procedural_aim"
+        "type": "procedural_aim",
+        "weapon_index": 0
       },
       "lerp_func": "not_being_built",
       "type": "fader"
@@ -51,7 +52,8 @@
       "child": {
         "rotation_axis": "z",
         "rotation_bone": "bone_turretLeft",
-        "type": "procedural_aim"
+        "type": "procedural_aim",
+        "weapon_index": 1
       },
       "lerp_func": "not_being_built",
       "type": "fader"
@@ -60,7 +62,8 @@
       "child": {
         "rotation_axis": "z",
         "rotation_bone": "bone_turretRight",
-        "type": "procedural_aim"
+        "type": "procedural_aim",
+        "weapon_index": 2
       },
       "lerp_func": "not_being_built",
       "type": "fader"

--- a/src/server/pa/units/land/l_bot_artillery_adv/l_bot_artillery_adv.json
+++ b/src/server/pa/units/land/l_bot_artillery_adv/l_bot_artillery_adv.json
@@ -177,7 +177,7 @@
         "socket_muzzleLeft02"
       ],
       "projectiles_per_fire": 1,
-      "record_index": 1,
+      "record_index": 2,
       "spec_id": "/pa/units/land/l_bot_artillery_adv/l_bot_artillery_adv_light_tool_weapon.json"
     }
   ],


### PR DESCRIPTION
Updated animation tree and unit JSON so that the side guns correctly animate to aim independently of the main gun.