### PR TITLE
Fixed Legion unit selections and hitboxes

### DIFF
--- a/src/server/pa/units/air/l_air_bomb/l_air_bomb.json
+++ b/src/server/pa/units/air/l_air_bomb/l_air_bomb.json
@@ -73,7 +73,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -24
+    "diameter": -14
   },
   "spawn_unit_on_death": "/pa/units/air/l_air_bomb/triggered/l_air_bomb.json",
   "spawn_unit_on_death_with_velocity": false,

--- a/src/server/pa/units/air/l_air_bomb/triggered/l_air_bomb.json
+++ b/src/server/pa/units/air/l_air_bomb/triggered/l_air_bomb.json
@@ -83,7 +83,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -24
+    "diameter": -14
   },
   "tools": [
     {

--- a/src/server/pa/units/air/l_air_carrier/l_air_carrier.json
+++ b/src/server/pa/units/air/l_air_carrier/l_air_carrier.json
@@ -110,7 +110,7 @@
     }
   ],
   "max_health": 2000,
-  "mesh_bounds": [12, 7.5, 4],
+  "mesh_bounds": [13, 18, 8],
   "model": {
     "arrows": 5,
     "filename": "/pa/units/air/l_air_carrier/l_air_carrier.papa"

--- a/src/server/pa/units/air/l_firestarter/l_drop_turret/l_drop_turret.json
+++ b/src/server/pa/units/air/l_firestarter/l_drop_turret/l_drop_turret.json
@@ -55,7 +55,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -10
+    "diameter": -16
   },
   "tools": [
     {

--- a/src/server/pa/units/air/l_firestarter/l_firestarter.json
+++ b/src/server/pa/units/air/l_firestarter/l_firestarter.json
@@ -61,7 +61,7 @@
   ],
   "guard_layer": "WL_AnySurface",
   "max_health": 1100,
-  "mesh_bounds": [4.5, 9.2, 4],
+  "mesh_bounds": [11, 15, 8],
   "model": {
     "animations": {
       "deploy": "/pa/units/air/l_firestarter/l_firestarter_deploy.papa",

--- a/src/server/pa/units/air/l_gunship/l_gunship.json
+++ b/src/server/pa/units/air/l_gunship/l_gunship.json
@@ -99,7 +99,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -16.0
+    "diameter": -20.0
   },
   "spawn_layers": "WL_Air",
   "tools": [

--- a/src/server/pa/units/air/l_titan_air/l_titan_air.json
+++ b/src/server/pa/units/air/l_titan_air/l_titan_air.json
@@ -72,7 +72,7 @@
   "guard_radius": 50,
   "has_death_effects": true,
   "max_health": 9000,
-  "mesh_bounds": [84, 77, 15],
+  "mesh_bounds": [72, 77, 15],
   "model": {
     "animtree": "/pa/anim/anim_trees/l_titan_air_anim_tree.json",
     "filename": "/pa/units/air/l_titan_air/l_titan_air.papa"
@@ -112,7 +112,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -72.0
+    "diameter": -82.0
   },
   "tools": [
     {

--- a/src/server/pa/units/land/l_air_defense/l_air_defense.json
+++ b/src/server/pa/units/land/l_air_defense/l_air_defense.json
@@ -23,7 +23,7 @@
   },
   "guard_layer": "WL_Air",
   "max_health": 1000,
-  "mesh_bounds": [9.634, 13.063, 7.819],
+  "mesh_bounds": [10, 10, 7.819],
   "model": [
     {
       "animations": {
@@ -63,7 +63,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -22
+    "diameter": -20
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "tools": [

--- a/src/server/pa/units/land/l_air_defense_adv/l_air_defense_adv.json
+++ b/src/server/pa/units/land/l_air_defense_adv/l_air_defense_adv.json
@@ -57,7 +57,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -16
+    "diameter": -30
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "tools": [

--- a/src/server/pa/units/land/l_artillery_long/l_artillery_long.json
+++ b/src/server/pa/units/land/l_artillery_long/l_artillery_long.json
@@ -44,7 +44,7 @@
     }
   ],
   "max_health": 5000,
-  "mesh_bounds": [22.227, 35.329, 14.856],
+  "mesh_bounds": [24, 24, 16],
   "model": [
     {
       "animations": {
@@ -84,7 +84,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -36
+    "diameter": -39
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "tools": [

--- a/src/server/pa/units/land/l_artillery_short/l_artillery_short.json
+++ b/src/server/pa/units/land/l_artillery_short/l_artillery_short.json
@@ -36,7 +36,7 @@
     }
   ],
   "max_health": 1000,
-  "mesh_bounds": [12.728, 14.757, 10.603],
+  "mesh_bounds": [12.728, 12.728, 10.603],
   "model": [
     {
       "animtree": "/pa/anim/anim_trees/l_artillery_anim_tree.json",

--- a/src/server/pa/units/land/l_bot_aa_adv/l_bot_aa_adv.json
+++ b/src/server/pa/units/land/l_bot_aa_adv/l_bot_aa_adv.json
@@ -28,7 +28,7 @@
   },
   "guard_layer": "WL_Air",
   "max_health": 400,
-  "mesh_bounds": [4.5, 3, 3.8],
+  "mesh_bounds": [6.5, 6.5, 8],
   "model": {
     "animations": {
       "idle": "/pa/units/land/l_bot_aa_adv/l_bot_aa_adv_idle.papa",
@@ -61,7 +61,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -8
+    "diameter": -17
   },
   "tools": [
     {

--- a/src/server/pa/units/land/l_bot_artillery/l_bot_artillery.json
+++ b/src/server/pa/units/land/l_bot_artillery/l_bot_artillery.json
@@ -53,7 +53,7 @@
     }
   ],
   "max_health": 125,
-  "mesh_bounds": [5, 5, 4.7],
+  "mesh_bounds": [10, 12, 8],
   "model": {
     "animations": {
       "idle": "/pa/units/land/l_bot_artillery/l_bot_artillery_idle.papa",
@@ -85,7 +85,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -18
+    "diameter": -23
   },
   "tools": [
     {

--- a/src/server/pa/units/land/l_bot_artillery_adv/l_bot_artillery_adv.json
+++ b/src/server/pa/units/land/l_bot_artillery_adv/l_bot_artillery_adv.json
@@ -108,7 +108,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -15
+    "diameter": -19
   },
   "tools": [
     {

--- a/src/server/pa/units/land/l_fabrication_vehicle_adv/l_fabrication_vehicle_adv.json
+++ b/src/server/pa/units/land/l_fabrication_vehicle_adv/l_fabrication_vehicle_adv.json
@@ -61,7 +61,7 @@
   ],
   "guard_layer": "WL_LandHorizontal",
   "max_health": 500,
-  "mesh_bounds": [5.2, 5.8, 3.5],
+  "mesh_bounds": [4.925, 7.123, 4.25],
   "model": {
     "animtree": "/pa/anim/anim_trees/fabrication_turret_anim_tree.json",
     "filename": "/pa/units/land/l_fabrication_vehicle_adv/l_fabrication_vehicle_adv.papa"

--- a/src/server/pa/units/land/l_flame_turret/l_flame_turret.json
+++ b/src/server/pa/units/land/l_flame_turret/l_flame_turret.json
@@ -35,7 +35,7 @@
   ],
   "guard_layer": "WL_AnySurface",
   "max_health": 4000,
-  "mesh_bounds": [13.397, 17.409, 10.889],
+  "mesh_bounds": [18.5, 18.5, 13.75],
   "model": [
     {
       "animtree": "/pa/anim/anim_trees/one_turret_mobile_anim_tree.json",

--- a/src/server/pa/units/land/l_hover_tank_adv/l_hover_tank_adv.json
+++ b/src/server/pa/units/land/l_hover_tank_adv/l_hover_tank_adv.json
@@ -86,7 +86,7 @@
     }
   ],
   "max_health": 200,
-  "mesh_bounds": [4.93769, 6.4, 2.6835],
+  "mesh_bounds": [6.468, 8, 5.711],
   "model": {
     "animations": {
       "hover": "/pa/units/land/tank_hover/tank_hover_anim_hover.papa"
@@ -118,7 +118,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -14
+    "diameter": -16
   },
   "tools": [
     {

--- a/src/server/pa/units/land/l_radar_adv/l_radar_adv.json
+++ b/src/server/pa/units/land/l_radar_adv/l_radar_adv.json
@@ -105,7 +105,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -29
+    "diameter": -35
   },
   "spawn_layers": "WL_AnySurface",
   "unit_types": [

--- a/src/server/pa/units/land/l_rocket_barrage/l_rocket_barrage.json
+++ b/src/server/pa/units/land/l_rocket_barrage/l_rocket_barrage.json
@@ -87,7 +87,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -30
+    "diameter": -33
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "tools": [

--- a/src/server/pa/units/land/l_shield_gen/l_shield_gen.json
+++ b/src/server/pa/units/land/l_shield_gen/l_shield_gen.json
@@ -38,7 +38,7 @@
     }
   ],
   "max_health": 750,
-  "mesh_bounds": [5, 5, 14],
+  "mesh_bounds": [4, 4, 14],
   "model": [
     {
       "animtree": "/pa/anim/anim_trees/bindpose_anim_tree.json",

--- a/src/server/pa/units/land/l_sniper_bot/l_sniper_bot.json
+++ b/src/server/pa/units/land/l_sniper_bot/l_sniper_bot.json
@@ -36,7 +36,7 @@
   },
   "guard_layer": "WL_AnySurface",
   "max_health": 120,
-  "mesh_bounds": [4, 2.5, 4],
+  "mesh_bounds": [4, 2.5, 4.5],
   "model": {
     "animations": {
       "idle": "/pa/units/land/l_sniper_bot/l_sniper_bot_idle.papa",

--- a/src/server/pa/units/land/l_storage/l_storage.json
+++ b/src/server/pa/units/land/l_storage/l_storage.json
@@ -72,7 +72,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -40
+    "diameter": -47
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "storage": {

--- a/src/server/pa/units/land/l_swarm_hive/l_swarm_hive.json
+++ b/src/server/pa/units/land/l_swarm_hive/l_swarm_hive.json
@@ -62,7 +62,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -28.0
+    "diameter": -31.0
   },
   "spawn_layers": "WL_AnyHorizontalGroundOrWaterSurface",
   "tools": [

--- a/src/server/pa/units/land/l_t1_turret_adv/l_t1_turret_adv.json
+++ b/src/server/pa/units/land/l_t1_turret_adv/l_t1_turret_adv.json
@@ -23,7 +23,8 @@
   },
   "guard_layer": "WL_AnySurface",
   "max_health": 2500,
-  "mesh_bounds": [13.397, 17.409, 10.889],
+  "mesh_bounds": [
+    13.397, 13.397, 11.889],
   "model": [
     {
       "animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json",

--- a/src/server/pa/units/land/l_t1_turret_basic/l_t1_turret_basic.json
+++ b/src/server/pa/units/land/l_t1_turret_basic/l_t1_turret_basic.json
@@ -23,7 +23,7 @@
   },
   "guard_layer": "WL_AnyHorizontalGroundOrWaterSurface",
   "max_health": 750,
-  "mesh_bounds": [10, 13.799, 10.112],
+  "mesh_bounds": [10, 10, 12.3],
   "model": [
     {
       "animtree": "/pa/anim/anim_trees/defense_turret_single_anim_tree.json",

--- a/src/server/pa/units/land/l_teleporter/l_teleporter.json
+++ b/src/server/pa/units/land/l_teleporter/l_teleporter.json
@@ -86,7 +86,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -75
+    "diameter": -90
   },
   "teleporter": {
     "energy_demand": 1000

--- a/src/server/pa/units/land/l_titan_bot/l_titan_bot.json
+++ b/src/server/pa/units/land/l_titan_bot/l_titan_bot.json
@@ -81,7 +81,7 @@
   "guard_layer": "WL_AnySurface",
   "has_death_effects": true,
   "max_health": 80000,
-  "mesh_bounds": [25, 25, 60],
+  "mesh_bounds": [34, 30, 60],
   "model": {
     "animations": {
       "walk": "/pa/units/land/l_titan_bot/l_titan_bot_walk.papa"

--- a/src/server/pa/units/land/l_titan_structure/l_titan_structure.json
+++ b/src/server/pa/units/land/l_titan_structure/l_titan_structure.json
@@ -103,7 +103,7 @@
   ],
   "has_death_effects": true,
   "max_health": 15000,
-  "mesh_bounds": [106, 106, 57],
+  "mesh_bounds": [77, 77, 57],
   "model": {
     "animations": {
       "dead": "/pa/units/land/titan_structure/titan_structure_anim_dead.papa",
@@ -141,7 +141,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -98.0
+    "diameter": -118.0
   },
   "tools": [
     {

--- a/src/server/pa/units/orbital/l_orbital_battleship/l_orbital_battleship.json
+++ b/src/server/pa/units/orbital/l_orbital_battleship/l_orbital_battleship.json
@@ -66,7 +66,7 @@
   "gravwell_velocity_multiplier": 6.0,
   "guard_layer": "WL_AnySurface",
   "max_health": 5500,
-  "mesh_bounds": [45, 77, 40.958],
+  "mesh_bounds": [45, 77, 15.958],
   "model": {
     "animtree": "/pa/anim/anim_trees/l_orbital_battleship_anim_tree.json",
     "filename": "/pa/units/orbital/l_orbital_battleship/l_orbital_battleship.papa"

--- a/src/server/pa/units/orbital/l_orbital_dropper/l_orbital_dropper.json
+++ b/src/server/pa/units/orbital/l_orbital_dropper/l_orbital_dropper.json
@@ -127,7 +127,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -70
+    "diameter": -90
   },
   "tools": [
     {

--- a/src/server/pa/units/orbital/l_orbital_railgun/l_orbital_railgun.json
+++ b/src/server/pa/units/orbital/l_orbital_railgun/l_orbital_railgun.json
@@ -87,7 +87,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -30.0
+    "diameter": -50.0
   },
   "tools": [
     {

--- a/src/server/pa/units/orbital/l_radar_satellite_adv/l_radar_satellite_adv.json
+++ b/src/server/pa/units/orbital/l_radar_satellite_adv/l_radar_satellite_adv.json
@@ -50,7 +50,7 @@
   ],
   "gravwell_velocity_multiplier": 6.0,
   "max_health": 2000,
-  "mesh_bounds": [25, 15, 15],
+  "mesh_bounds": [25, 25, 15],
   "model": {
     "animations": {
       "idle": "/pa/units/orbital/l_radar_satellite_adv/l_radar_satellite_adv_idle.papa"
@@ -106,7 +106,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -33
+    "diameter": -55
   },
   "tools": [
     {

--- a/src/server/pa/units/sea/l_torpedo_launcher/l_torpedo_launcher.json
+++ b/src/server/pa/units/sea/l_torpedo_launcher/l_torpedo_launcher.json
@@ -22,7 +22,7 @@
   },
   "guard_layer": "WL_WaterSurface",
   "max_health": 2000,
-  "mesh_bounds": [12, 6, 5],
+  "mesh_bounds": [12, 12, 5],
   "model": {
     "animtree": "/pa/anim/anim_trees/l_torpedo_launcher_anim_tree.json",
     "filename": "/pa/units/sea/l_torpedo_launcher/l_torpedo_launcher.papa"
@@ -58,7 +58,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -17
+    "diameter": -22
   },
   "spawn_layers": "WL_WaterSurface",
   "tools": [

--- a/src/server/pa/units/sea/l_torpedo_launcher_adv/l_torpedo_launcher_adv.json
+++ b/src/server/pa/units/sea/l_torpedo_launcher_adv/l_torpedo_launcher_adv.json
@@ -22,7 +22,7 @@
   },
   "guard_layer": "WL_WaterSurface",
   "max_health": 4000,
-  "mesh_bounds": [12, 6, 5],
+  "mesh_bounds": [30, 18, 6],
   "model": {
     "animations": {
       "idle": "/pa/units/sea/l_torpedo_launcher_adv/l_torpedo_launcher_adv_idle.papa"
@@ -61,7 +61,7 @@
     }
   },
   "selection_icon": {
-    "diameter": -17
+    "diameter": -42
   },
   "spawn_layers": "WL_WaterSurface",
   "tools": [


### PR DESCRIPTION
Check pull request for details on why units were updated.

# Pull Request Template

## Validation

- [x] I have followed the requirements of the Contributing document.
- [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully tested my changes locally.
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my changes generate no new warnings including when `install_devel.py` is run

## What does the change do?

A large amount of legion structures and units seemingly have never had their hitboxes and selection circles checked. I've gone through the legion unit set and updated those with inconsistent hitboxes and/or selection circles.

## Why should it be included?

Pretty clear these are oversights; I could point out a dozen examples where selecting a unit would not show a visible circle, structures clip, or the hitbox just doesn't fit the shape and size.

## How has this been tested?

All changed units have been spawned into sandbox, moved around, selected, and used. No new fields have been added to units, this pull request ONLY modifies existing hitboxes and selection radius.

## Full list of changes below:

### Land
- l_air_defense
  - made hitbox sqaure: the base of the turret is sqaure, and the turret itself can fire 360*, so there is no need for a rectagular hitbox.
  - slightly reduce selection circle: aa selection hex is slightly larger than needed.

- l_air_defense_adv
  - increased slection circle: adv aa selction hex is covered by the model (not visable).

- l_artillery_long
  - made hitbox sqaure: the base of the turret is sqaure, and the turret itself can fire 360*, so there is no need for a rectagular hitbox. Increased the height of the hitbox.
  - slightly increased slection circle: noticably shorter then other defences.

- l_artillery_short
  - made hitbox sqaure: the base of the turret is sqaure, and the turret itself can fire 360*, so there is no need for a rectagular hitbox.

- l_bot_aa_adv
  - greatly increased hitbox: the old hitbox shape and size was similar to that of a dox.
  - greatly increased slection circle: selction hex was the same size of a dox select circle.

- l_bot_artillery_adv
  - increased slection circle: selction hex was under the monstro.'s feet.

- l_bot_artillery
  - increased slection circle: selction cicle was a bit smaller than the feet profile
  - greatly increased hitbox: the old hitbox size was tiny compared to the model of this unit.

- l_fabrication_vehicle_adv
  - increased hitbox: the old hitbox shape and size was smaller than that of the t1 legion armor fabber, and didn't fit this unit's shape and size.

- l_flame_turret
  - changed hitbox: the old hitbox shape and size was similar to the other legion turrets; rectagular and streched along the y axis, which doesn't fit the shape of the arsonist (part of the model is sticking out of the hitbox, possible to clip multiple into each other).

- l_hover_tank_adv
  - increased hitbox: another case where the t2 hitbox was smaller than it's t1 equivelent.
  - slightly increased slection circle

- l_radar_adv
  - slightly increased slection circle: it was just barely bigger than the model, could look better

- l_rocket_barrage
  - slightly increased slection circle: it was just barely bigger than the model, could look better

- l_shield_gen
  - reduced hitbox: hitbox for the shield gen was quite a bit larger than the model and select circle.

- l_sniper_bot
  - increased height of hitbox: lancer's head was sticking out of the hitbox, which is almost the same as the dox's hitbox while being a larger unit.

- l_storage
  - increased slection circle: it was clipping with the model alot.

- l_swarm_hive
  - slightly increased slection circle: hive corner were clipping with the selction hex.

- l_t1_turret_adv
  - squred hitbox, increased hitbox height: better reflects shape of the turret

- l_t1_turret_basic
  - squred hitbox, increased hitbox height: better reflects shape of the turret

- l_teleporter
  - enlarged selection: Legion teleporters are real chonkers. 

- l_titan_bot
  - widen hitbox: The Thor is big. it's hitbox was a pilar. now the hitbox makes abit more sense, and should stop the thor from stepping on any unlucky units escorting it.

- l_titan_structure
  - slightly reduced hitbox: Getting a Holocene off can be a challenge with its thick hitbox, but it turns out it doesn't even need to be quite that large (You can hit 4 rag hitbox inside the old hol hitbox). Slightly reducing the hitbox should improve usage and will still look and feel fine.
	- increased selection ciricle: Select hex was getting covered by the unit. 

### Air
- l_air_bomb
  - reduced select circle: Nova selection circle is quite big for its size, and especially compared to other air units.

- l_air_carrier
  - lengthen hitbox: old hit box short, new one good.

- l_firestarter
  - increased hitbox: Im pretty sure nobody scaled up the hitbox for this guy from gunship
  - l_drop_turret
    - increased select circle: you can barely see it.

- l_gunship
  - selection circle increased: should be more visable

- l_titan_air
  - reduced width of hitbox: Loki had one of the biggest hitboxs in the game, no longer includes side engines in the hitbox.
  - selection circle increased: should be more visable

### Orbital

- l_radar_satellite_adv
  - squared shape of hitbox: matches unit shape
  - increased selection circle: old hex got covered by solar pannels.

- l_orbital_railgun
  - increased selection circle: Can you guess why?

- l_orbital_battleship
  - reduced hitbox hight: Oh boy it was tall.

- l_orbital_dropper
  - increased selection circle: More visable now and matches the girth of this factory

### Naval
- l_torpedo_launcher
  - Tweaked hitbox: you could clip these bad boys into each other.
  - Increased selection circle: More visable from regardless of direction aimed.

- l_torpedo_launcher_adv
  - Greatly increased hitbox: you could clip these bad boys into each other, way worse than any other unit in the game.
  - Increased selection circle: What selection circle? I don't see one.