### PR TITLE
check.py: Stop reporting missing files for Bug faction extractors

### DIFF
--- a/src/utils/check.py
+++ b/src/utils/check.py
@@ -36,6 +36,12 @@ def check_mod(client_output_dir, server_output_dir):
         sys.exit(1)
 
     checker.find_missing_files(report, fs)
+    # For compatibility with other mods, we may need to refer to their files
+    # without actually requiring that they are present.
+    # We specifically exclude them from the reporting of missing files here:
+    report.file_issues.pop("/pa/units/structure/bug_basic_extractor/bug_basic_extractor.json", None)
+    report.file_issues.pop("/pa/units/structure/bug_advanced_extractor/bug_advanced_extractor.json", None)
+
     if report.getIssueCount() > 0:
         print(report.printDetailsReport())
         print(report.printJsonIssueReport())

--- a/src/utils/check.py
+++ b/src/utils/check.py
@@ -38,12 +38,12 @@ def check_mod(client_output_dir, server_output_dir):
     checker.find_missing_files(report, fs)
     # For compatibility with other mods, we may need to refer to their files
     # without actually requiring that they are present.
-    allow_missing_files = [
+    ALLOW_MISSING_FILES = [
         # Bugs Faction
         "/pa/units/structure/bug_basic_extractor/bug_basic_extractor.json",
         "/pa/units/structure/bug_advanced_extractor/bug_advanced_extractor.json",
     ]
-    for allowed_missing in allow_missing_files:
+    for allowed_missing in ALLOW_MISSING_FILES:
         report.file_issues.pop(allowed_missing, None)
 
     if report.getIssueCount() > 0:

--- a/src/utils/check.py
+++ b/src/utils/check.py
@@ -38,9 +38,13 @@ def check_mod(client_output_dir, server_output_dir):
     checker.find_missing_files(report, fs)
     # For compatibility with other mods, we may need to refer to their files
     # without actually requiring that they are present.
-    # We specifically exclude them from the reporting of missing files here:
-    report.file_issues.pop("/pa/units/structure/bug_basic_extractor/bug_basic_extractor.json", None)
-    report.file_issues.pop("/pa/units/structure/bug_advanced_extractor/bug_advanced_extractor.json", None)
+    allow_missing_files = [
+        # Bugs Faction
+        "/pa/units/structure/bug_basic_extractor/bug_basic_extractor.json",
+        "/pa/units/structure/bug_advanced_extractor/bug_advanced_extractor.json",
+    ]
+    for allowed_missing in allow_missing_files:
+        report.file_issues.pop(allowed_missing, None)
 
     if report.getIssueCount() > 0:
         print(report.printDetailsReport())


### PR DESCRIPTION
# Pull Request Template

## Validation

- [x] I have followed the requirements of the Contributing document.
- [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have successfully tested my changes locally.
- [x] I have made corresponding changes to the documentation.
- [x] I have checked my changes generate no new warnings including when `install_devel.py` is run.

## What does the change do?

Silences spurious error messages for files we know might be missing (Bug extractor unit jsons)

## Why should it be included?

It keeps the check step 'green'.

## How has this been tested?

Ran both install_prod.py and install_devel.py and they have both stopped reporting these files are missing.

Also checked that removing any other files still report errors.