### PR TITLE
Viper range decreased to Avenger range

### DIFF
--- a/src/server/pa/units/orbital/l_orbital_fighter/l_orbital_fighter_tool_weapon.json
+++ b/src/server/pa/units/orbital/l_orbital_fighter/l_orbital_fighter_tool_weapon.json
@@ -4,7 +4,7 @@
   "base_spec": "/pa/tools/base_fighter_turret/base_fighter_turret.json",
   "firing_arc_pitch": 15,
   "firing_arc_yaw": 5,
-  "max_range": 200,
+  "max_range": 100,
   "pitch_range": 20,
   "rate_of_fire": 0.7,
   "target_layers": ["WL_Orbital"],


### PR DESCRIPTION
# Pull Request Template

## Validation

- [-] I have followed the requirements of the Contributing document.
- [+] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
- [-] I have commented my code, particularly in hard-to-understand areas.
- [+] I have successfully tested my changes locally.
- [-] I have made corresponding changes to the documentation.
- [-] I have checked my changes generate no new warnings including when `install_devel.py` is run.

## What does the change do?

Makes viper attack range same as avenger attack range

## Why should it be included?

Viper in current state is very OP

## How has this been tested?

Theoretically 
