### PR TITLE
Update server and client modinfo dates unconditionally

### DIFF
--- a/src/utils/build.py
+++ b/src/utils/build.py
@@ -5,6 +5,7 @@
 import copy
 import shutil
 import glob
+from datetime import date
 
 from os.path import join
 
@@ -83,9 +84,12 @@ def generate_mods(is_dev_mode):
 
     old_modinfo = load_json(fs, "/mod/modinfo.json")
 
-    # Update build version and date
+    # Update build version
     server_modinfo = update_modinfo(server_modinfo, old_modinfo)
     client_modinfo = update_modinfo(client_modinfo, old_modinfo)
+    # Update dates
+    server_modinfo["date"] = date.today().strftime("%Y-%m-%d")
+    client_modinfo["date"] = date.today().strftime("%Y-%m-%d")
 
     # Remove old files
     print(f"CLEAN {server_output_dir}")


### PR DESCRIPTION
# Pull Request Template

## Validation

- [ ] I have followed the requirements of the Contributing document.
- [ ] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have successfully tested my changes locally.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have checked my changes generate no new warnings including when `install_devel.py` is run.

## What does the change do?

Previously, building the server and client mods would only update the the modinfo build date if the PA build number changed, or the mod did not exist before.

This changes the build to always update the modinfo dates to the current date.

## Why should it be included?

It is a personal request <3

## How has this been tested?

I've verified that the date property does not get updated to the current date without this change (and does with this change).
